### PR TITLE
Add EasyBind.concat(List<ObservableList<T>>)

### DIFF
--- a/src/main/java/org/fxmisc/easybind/ConcatList.java
+++ b/src/main/java/org/fxmisc/easybind/ConcatList.java
@@ -1,0 +1,92 @@
+package org.fxmisc.easybind;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableListBase;
+
+class ConcatList<E> extends ObservableListBase<E> {
+	private final List<ObservableList<? extends E>> sourceLists;
+
+	public ObservableConcatList(List<ObservableList<? extends E>> sourceLists) {
+		assert sourceLists != null;
+		this.sourceLists = sourceLists;
+		for (ObservableList<? extends E> source : sourceLists)
+			source.addListener(this::onSourceListChanged);
+	}
+
+	private void onSourceListChanged(ListChangeListener.Change<? extends E> change) {
+		ObservableList<? extends E> source = change.getList();
+		int indexOffset = 0;
+		for (int i = 0; sourceLists.get(i) != source; ++i)
+			indexOffset += sourceLists.get(i).size();
+
+		beginChange();
+		while (change.next()) {
+			if (change.wasPermutated()) {
+				int rangeSize = change.getTo() - change.getFrom();
+				int[] permutation = new int[rangeSize];
+				for (int i = 0; i < rangeSize; ++i)
+					permutation[i] = change.getPermutation(i + change.getFrom()) + indexOffset;
+				nextPermutation(change.getFrom() + indexOffset, change.getTo() + indexOffset, permutation);
+			} else if (change.wasUpdated()) {
+				for (int i = change.getFrom(); i < change.getTo(); ++i)
+					nextUpdate(i+indexOffset);
+			} else if (change.wasAdded()) {
+				nextAdd(change.getFrom()+indexOffset, change.getTo()+indexOffset);
+			} else
+				nextRemove(change.getFrom()+indexOffset, change.getRemoved());
+		}
+		endChange();
+	}
+
+	@Override
+	public E get(int index) {
+		if (index < 0)
+			throw new IndexOutOfBoundsException("List index must be >= 0. Was " + index);
+
+		for (ObservableList<? extends E> source : sourceLists) {
+			if (index < source.size())
+				return source.get(index);
+			index -= source.size();
+		}
+		throw new IndexOutOfBoundsException("Index too large.");
+	}
+
+	@Override
+	public Iterator<E> iterator() {
+		return new Iterator<E>() {
+			Iterator<ObservableList<? extends E>> sourceIterator = sourceLists.iterator();
+			Iterator<? extends E> currentIterator = null;
+
+			@Override
+			public boolean hasNext() {
+				while (currentIterator == null || !currentIterator.hasNext())
+					if (sourceIterator.hasNext())
+						currentIterator = sourceIterator.next().iterator();
+					else
+						return false;
+				return true;
+			}
+
+			@Override
+			public E next() {
+				while (currentIterator == null || !currentIterator.hasNext())
+					if (sourceIterator.hasNext())
+						currentIterator = sourceIterator.next().iterator();
+					else
+						throw new NoSuchElementException();
+				return currentIterator.next();
+			}
+		};
+	}
+
+	@Override
+	public int size() {
+		return sourceLists.stream().mapToInt(ObservableList<? extends E>::size).sum();
+	}
+}

--- a/src/main/java/org/fxmisc/easybind/ConcatList.java
+++ b/src/main/java/org/fxmisc/easybind/ConcatList.java
@@ -1,6 +1,5 @@
 package org.fxmisc.easybind;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -12,7 +11,7 @@ import javafx.collections.ObservableListBase;
 class ConcatList<E> extends ObservableListBase<E> {
 	private final List<ObservableList<? extends E>> sourceLists;
 
-	public ObservableConcatList(List<ObservableList<? extends E>> sourceLists) {
+	public ConcatList(List<ObservableList<? extends E>> sourceLists) {
 		assert sourceLists != null;
 		this.sourceLists = sourceLists;
 		for (ObservableList<? extends E> source : sourceLists)

--- a/src/main/java/org/fxmisc/easybind/EasyBind.java
+++ b/src/main/java/org/fxmisc/easybind/EasyBind.java
@@ -1,5 +1,6 @@
 package org.fxmisc.easybind;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -114,6 +115,16 @@ public class EasyBind {
             ObservableList<? extends T> sourceList,
             Function<? super T, ? extends U> f) {
         return new MappedList<>(sourceList, f);
+    }
+
+    public static <T> ObservableList<T> concat(
+            List<ObservableList<T>> sources) {
+        return new ConcatList<>(sources);
+    }
+
+    public static <T> ObservableList<T> concat(
+            ObservableList<T>... sources) {
+        return new ConcatList<>(Arrays.asList(sources));
     }
 
     public static <A, B, R> MonadicBinding<R> combine(

--- a/src/main/java/org/fxmisc/easybind/EasyBind.java
+++ b/src/main/java/org/fxmisc/easybind/EasyBind.java
@@ -118,12 +118,12 @@ public class EasyBind {
     }
 
     public static <T> ObservableList<T> concat(
-            List<ObservableList<T>> sources) {
+            List<ObservableList<? extends T>> sources) {
         return new ConcatList<>(sources);
     }
 
     public static <T> ObservableList<T> concat(
-            ObservableList<T>... sources) {
+            ObservableList<? extends T>... sources) {
         return new ConcatList<>(Arrays.asList(sources));
     }
 

--- a/src/test/java/org/fxmisc/easybind/ConcatListTest.java
+++ b/src/test/java/org/fxmisc/easybind/ConcatListTest.java
@@ -1,0 +1,45 @@
+package org.fxmisc.easybind;
+
+import static org.junit.Assert.*;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.StringBinding;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import org.junit.Test;
+
+public class ConcatListTest {
+	@Test
+	public void test() {
+		ObservableList<String> a = FXCollections.observableArrayList("zero", "one", "two");
+		ObservableList<String> b = FXCollections.observableArrayList("three", "four", "five");
+		ObservableList<String> c = EasyBind.concat(a, b);
+		ObservableList<String> d = EasyBind.concat(a, a);
+
+		StringBinding bindOne = Bindings.stringValueAt(c, 1);
+		StringBinding bindFour = Bindings.stringValueAt(c, 4);
+
+		assertEquals(6, c.size());
+		assertEquals("one", bindOne.get());
+		assertEquals("five", c.get(5));
+
+		a.remove(1);
+		assertEquals(5, c.size());
+		assertEquals("three", c.get(2));
+		assertEquals("two", bindOne.get());
+		assertEquals("five", bindFour.get());
+
+		b.add(1, "x");
+		assertEquals(6, c.size());
+		assertEquals("x", c.get(3));
+		assertEquals("four", bindFour.get());
+
+		a.set(0, "null");
+		assertEquals("null", c.get(0));
+
+		assertEquals(4, d.size());
+		assertEquals("two", d.get(1));
+		assertEquals("null", d.get(2));
+	}
+}


### PR DESCRIPTION
Creates a new list that combines the values of the given lists. Unlike `FXCollections.concat()`, updates to the source lists propagate to the combined list.

I needed this for a project of mine, so I hacked it together. Since it might be useful to others as well, I thought I'd submit it here. If there are any changes you'd like me to make, let me know.
